### PR TITLE
Add Temperature Sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ build/
 # Other
 *.tar.gz
 .idea/
+.vs/
 img_data/

--- a/src/globals.h
+++ b/src/globals.h
@@ -13,9 +13,13 @@ namespace constants {
 }
 
 // Error codes
-enum Status {
+enum [[nodiscard]] Status {
     SUCCESS,
     FAILURE,
+    I2C_SETUP_FAILURE,
+    I2C_WRITE_FAILURE,
+    I2C_READ_FAILURE,
+    INVALID_INPUT,
 };
 
 #endif

--- a/src/sensors/ADS7828.cpp
+++ b/src/sensors/ADS7828.cpp
@@ -1,6 +1,6 @@
 #include "ADS7828.h"
 
-#include <cstdint>
+#include <cmath>
 #include <wiringPi.h>
 #include <wiringPiI2C.h>
 
@@ -16,16 +16,30 @@ ADS7828::ADS7828(const char* device, bool addr1, bool addr2, int& err) {
 	else {
 		err = 0;
 	}
+	this->referenceVoltage = 2.5;
 }
 
-uint16_t ADS7828::readChannelCommonAnode(int channel, int& err) {
+ADS7828::ADS7828(const char* device, bool addr1, bool addr2, int& err, double referenceVoltage) {
+	address = 0b01001000 + 2 * addr1 + addr2;
+	fd = wiringPiI2CSetupInterface(device, address);
+	if (fd == -1) {
+		address = 255;
+		err = -1; // I2C setup for this device failed
+	}
+	else {
+		err = 0;
+	}
+	this->referenceVoltage = referenceVoltage;
+}
+
+double ADS7828::readChannelCommonAnode(int channel, int& err) {
 	if (channel >= 8 || channel < 0) {
 		err = -1; // Bad input: invalid channel
-		return 0xffff;
+		return std::nan;
 	}
 	if (fd == -1) {
 		err = -1; // I2C setup for this device failed
-		return 0xffff;
+		return std::nan;
 	}
 	uint8_t cmd = 56 * (channel & 1) + 8 * channel + 140;
 	if (cmd != lastCmd) {
@@ -33,28 +47,28 @@ uint16_t ADS7828::readChannelCommonAnode(int channel, int& err) {
 		if (res < 0) {
 			lastCmd = 255;
 			err = -1; // I2C write failure to this device
-			return 0xffff;
+			return std:nan;
 		}
 	}
 	int res = wiringPiI2CRead(fd);
 	if (res < 0 || res > MAX_READ_VALUE) {
 		err = -1; // I2C read failure to this device
-		return 0xffff;
+		return std::nan;
 	}
 	err = 0;
-	return res;
+	return res * referenceVoltage / (1 << 12);
 }
 
 // pair 0 is 0,1; pair 1 is 2,3; pair 2 is 4,5; pair 3 is 6,7
 // if the pair is inverted, the positive input is the larger channel number
-uint16_t ADS7828::readChannelDifferentialPair(int pair, bool inverted, int& err) {
+double ADS7828::readChannelDifferentialPair(int pair, bool inverted, int& err) {
 	if (pair >= 4 || pair < 0) {
 		err = -1; // Bad input: invalid pair
-		return 0xffff;
+		return std::nan;
 	}
 	if (fd == -1) {
 		err = -1; // I2C setup for this device failed
-		return 0xffff;
+		return std::nan;
 	}
 	uint8_t cmd = 12 + inverted * 64 + pair * 16;
 	if (cmd != lastCmd) {
@@ -62,19 +76,19 @@ uint16_t ADS7828::readChannelDifferentialPair(int pair, bool inverted, int& err)
 		if (res < 0) {
 			lastCmd = 255;
 			err = -1; // I2C write failure to this device
-			return 0xffff;
+			return std::nan;
 		}
 	}
 	int res = wiringPiI2CRead(fd);
 	if (res < 0 || res > MAX_READ_VALUE) {
 		err = -1; // I2C read failure to this device
-		return 0xffff;
+		return std::nan;
 	}
 	err = 0;
-	return res;
+	return res * referenceVoltage / (1 << 12);
 }
 
-uint16_t ADS7828::readChannelDifferentialPair(int pair, int& err) {
+double ADS7828::readChannelDifferentialPair(int pair, int& err) {
 	return readChannelDifferentialPair(pair, false, err);
 }
 

--- a/src/sensors/ADS7828.cpp
+++ b/src/sensors/ADS7828.cpp
@@ -1,0 +1,96 @@
+#include "ADS7828.h"
+
+#include <cstdint>
+#include <wiringPi.h>
+#include <wiringPiI2C.h>
+
+// Begin Possible States
+const char NOT_INIT[] = "FAILED TO INITIALIZE DEVICE";
+const char WORKING[] = "TAKING SAMPLES";
+const char ASLEEP[] = "DEVICE TURNED OFF";
+const char ERROR[] = "ERROR EXECUTING LAST COMMAND";
+// End Possible States
+
+const MAX_READ_VALUE = (1 << 12) - 1;
+
+ADS7828::ADS7828(bool addr1, bool addr2) {
+	address = 0b01001000 + 2 * addr1 + addr2;
+	fd = wiringPiI2CSetup(address);
+	if (fd == -1) {
+		address = 255;
+		state = NOT_INIT;
+	}
+	else {
+		state = WORKING;
+	}
+}
+
+uint16_t ADS7828::readChannelCommonAnode(int channel) {
+	if (channel >= 8 || channel < 0 || fd == -1) {
+		return 0xffff;
+	}
+	uint8_t cmd = 56 * (channel & 1) + 8 * channel + 140;
+	if (cmd != lastCmd) {
+		int res = wiringPiI2CWrite(fd, cmd);
+		if (res < 0) {
+			lastCmd = 255;
+			state = ERROR;
+			return 0xffff;
+		}
+	}
+	int res = wiringPiI2CRead(fd);
+	if (res < 0 || res > MAX_READ_VALUE) {
+		state = ERROR;
+		return 0xffff;
+	}
+	state = WORKING;
+	return res;
+}
+
+// pair 0 is 0,1; pair 1 is 2,3; pair 2 is 4,5; pair 3 is 6,7
+// if the pair is inverted, the positive input is the larger channel number
+uint16_t ADS7828::readChannelDifferentialPair(int pair, bool inverted) {
+	if (pair >= 4 || pair < 0 || fd == -1) {
+		return 0xffff;
+	}
+	uint8_t cmd = 12 + inverted * 64 + pair * 16;
+	if (cmd != lastCmd) {
+		int res = wiringPiI2CWrite(fd, cmd);
+		if (res < 0) {
+			lastCmd = 255;
+			state = ERROR;
+			return 0xffff;
+		}
+	}
+	int res = wiringPiI2CRead(fd);
+	if (res < 0 || res > MAX_READ_VALUE) {
+		state = ERROR;
+		return 0xffff;
+	}
+	state = WORKING;
+	return res;
+}
+
+uint16_t ADS7828::readChannelDifferentialPair(int pair) {
+	return readChannelDifferentialPair(pair, false);
+}
+
+void ADS7828::setRunning(bool running) {
+	if (fd == -1) return;
+	uint8_t cmd = lastCmd & 0xf0 + running * 0xc;
+	if (cmd != lastCmd) {
+		int res = wiringPiI2CWrite(fd, cmd);
+		if (res < 0) {
+			lastCmd = 255;
+			state = ERROR;
+		}
+		else {
+			lastCmd = cmd;
+			state = running ? WORKING : ASLEEP;
+		}
+	}
+}
+
+const char* ADS7828::getState() {
+	return state;
+}

--- a/src/sensors/ADS7828.cpp
+++ b/src/sensors/ADS7828.cpp
@@ -4,109 +4,99 @@
 #include <wiringPi.h>
 #include <wiringPiI2C.h>
 
+#include "../globals.h"
+
 const MAX_READ_VALUE = (1 << 12) - 1;
 
-ADS7828::ADS7828(const char* device, bool addr1, bool addr2, int& err) {
+ADS7828::ADS7828(const char* device, bool addr1, bool addr2, Status& err) {
 	address = 0b01001000 + 2 * addr1 + addr2;
 	fd = wiringPiI2CSetupInterface(device, address);
 	if (fd == -1) {
 		address = 255;
-		err = -1; // I2C setup for this device failed
+		err = I2C_SETUP_FAILURE;
 	}
 	else {
-		err = 0;
+		err = SUCCESS;
 	}
 	this->referenceVoltage = 2.5;
 }
 
-ADS7828::ADS7828(const char* device, bool addr1, bool addr2, int& err, double referenceVoltage) {
+ADS7828::ADS7828(const char* device, bool addr1, bool addr2, double referenceVoltage, Status& err) {
 	address = 0b01001000 + 2 * addr1 + addr2;
 	fd = wiringPiI2CSetupInterface(device, address);
 	if (fd == -1) {
 		address = 255;
-		err = -1; // I2C setup for this device failed
-	}
-	else {
-		err = 0;
+		err = I2C_SETUP_FAILURE;
 	}
 	this->referenceVoltage = referenceVoltage;
 }
 
-double ADS7828::readChannelCommonAnode(int channel, int& err) {
+Status ADS7828::readChannelCommonAnode(int channel, double& value) {
 	if (channel >= 8 || channel < 0) {
-		err = -1; // Bad input: invalid channel
-		return std::nan;
+		return INVALID_INPUT; // Bad input: invalid channel
 	}
 	if (fd == -1) {
-		err = -1; // I2C setup for this device failed
-		return std::nan;
+		return I2C_SETUP_FAILURE;
 	}
 	uint8_t cmd = 56 * (channel & 1) + 8 * channel + 140;
 	if (cmd != lastCmd) {
 		int res = wiringPiI2CWrite(fd, cmd);
 		if (res < 0) {
 			lastCmd = 255;
-			err = -1; // I2C write failure to this device
-			return std:nan;
+			return I2C_WRITE_FAILURE;
 		}
 	}
 	int res = wiringPiI2CRead(fd);
 	if (res < 0 || res > MAX_READ_VALUE) {
-		err = -1; // I2C read failure to this device
-		return std::nan;
+		return I2C_READ_FAILURE;
 	}
-	err = 0;
-	return res * referenceVoltage / (1 << 12);
+	value = res * referenceVoltage / (1 << 12);
+	return SUCCESS;
 }
 
 // pair 0 is 0,1; pair 1 is 2,3; pair 2 is 4,5; pair 3 is 6,7
 // if the pair is inverted, the positive input is the larger channel number
-double ADS7828::readChannelDifferentialPair(int pair, bool inverted, int& err) {
+Status ADS7828::readChannelDifferentialPair(int pair, bool inverted, double& value) {
 	if (pair >= 4 || pair < 0) {
-		err = -1; // Bad input: invalid pair
-		return std::nan;
+		return INVALID_INPUT; // Bad input: invalid pair
 	}
 	if (fd == -1) {
-		err = -1; // I2C setup for this device failed
-		return std::nan;
+		return I2C_SETUP_FAILURE;
 	}
 	uint8_t cmd = 12 + inverted * 64 + pair * 16;
 	if (cmd != lastCmd) {
 		int res = wiringPiI2CWrite(fd, cmd);
 		if (res < 0) {
 			lastCmd = 255;
-			err = -1; // I2C write failure to this device
-			return std::nan;
+			return I2C_WRITE_FAILURE;
 		}
 	}
 	int res = wiringPiI2CRead(fd);
 	if (res < 0 || res > MAX_READ_VALUE) {
-		err = -1; // I2C read failure to this device
-		return std::nan;
+		return I2C_READ_FAILURE;
 	}
-	err = 0;
-	return res * referenceVoltage / (1 << 12);
+	value = res * referenceVoltage / (1 << 12)
+	return SUCCESS;
 }
 
-double ADS7828::readChannelDifferentialPair(int pair, int& err) {
-	return readChannelDifferentialPair(pair, false, err);
+double ADS7828::readChannelDifferentialPair(int pair, double& value) {
+	return readChannelDifferentialPair(pair, false, value);
 }
 
-void ADS7828::setRunning(bool running, int& err) {
+Status ADS7828::setRunning(bool running) {
 	if (fd == -1) {
-		err = -1; // I2C setup for this device failed
-		return;
+		return I2C_SETUP_FAILURE;
 	}
 	uint8_t cmd = lastCmd & 0xf0 + running * 0xc;
 	if (cmd != lastCmd) {
 		int res = wiringPiI2CWrite(fd, cmd);
 		if (res < 0) {
 			lastCmd = 255;
-			err = -1; // I2C write failure to this device
+			return I2C_WRITE_FAILURE;
 		}
 		else {
 			lastCmd = cmd;
-			err = 0;
+			return SUCCESS;
 		}
 	}
 }

--- a/src/sensors/ADS7828.cpp
+++ b/src/sensors/ADS7828.cpp
@@ -8,27 +8,14 @@
 
 const MAX_READ_VALUE = (1 << 12) - 1;
 
-ADS7828::ADS7828(const char* device, bool addr1, bool addr2, Status& err) {
-	address = 0b01001000 + 2 * addr1 + addr2;
+ADS7828::ADS7828(const char* device, bool addr1, bool addr2, double referenceVoltage) {
+	uint8_t address = 0b01001000 + 2 * addr1 + addr2;
 	fd = wiringPiI2CSetupInterface(device, address);
-	if (fd == -1) {
-		address = 255;
-		err = I2C_SETUP_FAILURE;
-	}
-	else {
-		err = SUCCESS;
-	}
-	this->referenceVoltage = 2.5;
+	this->referenceVoltage = referenceVoltage;
 }
 
-ADS7828::ADS7828(const char* device, bool addr1, bool addr2, double referenceVoltage, Status& err) {
-	address = 0b01001000 + 2 * addr1 + addr2;
-	fd = wiringPiI2CSetupInterface(device, address);
-	if (fd == -1) {
-		address = 255;
-		err = I2C_SETUP_FAILURE;
-	}
-	this->referenceVoltage = referenceVoltage;
+Status ADS7828::init() {
+	return fd == -1 ? I2C_SETUP_FAILURE : SUCCESS;
 }
 
 Status ADS7828::readChannelCommonAnode(int channel, double& value) {

--- a/src/sensors/ADS7828.cpp
+++ b/src/sensors/ADS7828.cpp
@@ -13,9 +13,9 @@ const char ERROR[] = "ERROR EXECUTING LAST COMMAND";
 
 const MAX_READ_VALUE = (1 << 12) - 1;
 
-ADS7828::ADS7828(bool addr1, bool addr2) {
+ADS7828::ADS7828(const char* device, bool addr1, bool addr2) {
 	address = 0b01001000 + 2 * addr1 + addr2;
-	fd = wiringPiI2CSetup(address);
+	fd = wiringPiI2CSetupInterface(device, address);
 	if (fd == -1) {
 		address = 255;
 		state = NOT_INIT;

--- a/src/sensors/ADS7828.h
+++ b/src/sensors/ADS7828.h
@@ -1,0 +1,21 @@
+#ifndef ADS7828
+#define ADS7828
+
+#include <cstdint>
+
+class ADS7828 {
+public:
+	ADS7828(bool addr0, bool addr1);
+	uint16_t readChannelCommonAnode(int channel);
+	uint16_t readChannelDifferentialPair(int pair, bool inverted);
+	uint16_t readChannelDifferentialPair(int pair);
+	void setRunning(bool running);
+	const char* getState();
+private:
+	uint8_t address;
+	const char* state;
+	uint8_t lastCmd;
+	int fd;
+}
+
+#endif

--- a/src/sensors/ADS7828.h
+++ b/src/sensors/ADS7828.h
@@ -5,14 +5,13 @@
 
 class ADS7828 {
 public:
-	ADS7828(const char* device, bool addr0, bool addr1, Status& err);
-	ADS7828(const char* device, bool addr0, bool addr1, double referenceVoltage, Status& err);
+	ADS7828(const char* device, bool addr0, bool addr1, double referenceVoltage = 2.5);
+	[[nodiscard]] Status init();
 	[[nodiscard]] Status readChannelCommonAnode(int channel, double& value);
 	[[nodiscard]] Status readChannelDifferentialPair(int pair, bool inverted, double& value);
 	[[nodiscard]] Status readChannelDifferentialPair(int pair, double& value);
 	[[nodiscard]] Status setRunning(bool running);
 private:
-	uint8_t address;
 	double referenceVoltage;
 	uint8_t lastCmd;
 	int fd;

--- a/src/sensors/ADS7828.h
+++ b/src/sensors/ADS7828.h
@@ -5,15 +5,13 @@
 
 class ADS7828 {
 public:
-	ADS7828(const char* device, bool addr0, bool addr1);
-	uint16_t readChannelCommonAnode(int channel);
-	uint16_t readChannelDifferentialPair(int pair, bool inverted);
-	uint16_t readChannelDifferentialPair(int pair);
-	void setRunning(bool running);
-	const char* getState();
+	ADS7828(const char* device, bool addr0, bool addr1, int& err);
+	uint16_t readChannelCommonAnode(int channel, int& err);
+	uint16_t readChannelDifferentialPair(int pair, bool inverted, int& err);
+	uint16_t readChannelDifferentialPair(int pair, int& err);
+	void setRunning(bool running, int& err);
 private:
 	uint8_t address;
-	const char* state;
 	uint8_t lastCmd;
 	int fd;
 }

--- a/src/sensors/ADS7828.h
+++ b/src/sensors/ADS7828.h
@@ -6,12 +6,14 @@
 class ADS7828 {
 public:
 	ADS7828(const char* device, bool addr0, bool addr1, int& err);
-	uint16_t readChannelCommonAnode(int channel, int& err);
-	uint16_t readChannelDifferentialPair(int pair, bool inverted, int& err);
-	uint16_t readChannelDifferentialPair(int pair, int& err);
+	ADS7828(const char* device, bool addr0, bool addr1, int& err, referenceVoltage);
+	double readChannelCommonAnode(int channel, int& err);
+	double readChannelDifferentialPair(int pair, bool inverted, int& err);
+	double readChannelDifferentialPair(int pair, int& err);
 	void setRunning(bool running, int& err);
 private:
 	uint8_t address;
+	double referenceVoltage;
 	uint8_t lastCmd;
 	int fd;
 }

--- a/src/sensors/ADS7828.h
+++ b/src/sensors/ADS7828.h
@@ -5,12 +5,12 @@
 
 class ADS7828 {
 public:
-	ADS7828(const char* device, bool addr0, bool addr1, int& err);
-	ADS7828(const char* device, bool addr0, bool addr1, int& err, referenceVoltage);
-	double readChannelCommonAnode(int channel, int& err);
-	double readChannelDifferentialPair(int pair, bool inverted, int& err);
-	double readChannelDifferentialPair(int pair, int& err);
-	void setRunning(bool running, int& err);
+	ADS7828(const char* device, bool addr0, bool addr1, Status& err);
+	ADS7828(const char* device, bool addr0, bool addr1, double referenceVoltage, Status& err);
+	[[nodiscard]] Status readChannelCommonAnode(int channel, double& value);
+	[[nodiscard]] Status readChannelDifferentialPair(int pair, bool inverted, double& value);
+	[[nodiscard]] Status readChannelDifferentialPair(int pair, double& value);
+	[[nodiscard]] Status setRunning(bool running);
 private:
 	uint8_t address;
 	double referenceVoltage;

--- a/src/sensors/ADS7828.h
+++ b/src/sensors/ADS7828.h
@@ -5,7 +5,7 @@
 
 class ADS7828 {
 public:
-	ADS7828(bool addr0, bool addr1);
+	ADS7828(const char* device, bool addr0, bool addr1);
 	uint16_t readChannelCommonAnode(int channel);
 	uint16_t readChannelDifferentialPair(int pair, bool inverted);
 	uint16_t readChannelDifferentialPair(int pair);

--- a/src/sensors/PPG102A6.cpp
+++ b/src/sensors/PPG102A6.cpp
@@ -1,11 +1,33 @@
 #include "PPG102A6.h"
 
-#include "ina260.h"
+#include <wiringPi.h>
 
-PPG102A6::PPG102A6(ina260* sensor) : resistanceAtZero(1000), ppmPerDegree(3850), sensor(sensor) {}
+PPG102A6::PPG102A6(ADS7828* sensor, int channel, int gpioPin) {
+	resistanceAtZero = 1000;
+	ppmPerDegree = 3850;
+	this->sensor = sensor;
+	// Expected resistance of the RTD at 50 degrees C.
+	// Choosing this value maximizes the minimum value for
+	// d(Voltage)/d(Temperature) on the range -40 to +50
+	// degrees C. If this exact value of resistor cannot be
+	// ordered, the real value should be used.
+	this->dividerResistance = 1192.5;
+
+	this->channel = channel;
+	this->gpioPin = gpioPin;
+
+	pinMode(gpioPin, OUTPUT);
+	pullUpDnControl(gpioPin, PUD_OFF);
+	digitalWrite(gpioPin, LOW);
+}
 
 double PPG102A6::getTemperature() {
-	// using R = R0 * (10^6 + ppm * T) and V = IR
-	double resistance = sensor->readVoltage_mV() / sensor->readCurrent_mA();
+	digitalWrite(gpioPin, HIGH);
+	double voltage = sensor->readChannelCommonAnode(channel);
+	digitalWrite(gpioPin, LOW);
+	// using V = IR
+	double current = voltage / dividerResistance;
+	double resistance = voltage / current;
+	// using R = R0 * (10^6 + ppm * T)
 	return (resistance / resistanceAtZero - 1000000) / ppmPerDegree;
 }

--- a/src/sensors/PPG102A6.cpp
+++ b/src/sensors/PPG102A6.cpp
@@ -1,0 +1,11 @@
+#include "PPG102A6.h"
+
+#include "ina260.h"
+
+PPG102A6::PPG102A6(ina260* sensor) : resistanceAtZero(1000), ppmPerDegree(3850), sensor(sensor) {}
+
+double PPG102A6::getTemperature() {
+	// using R = R0 * (10^6 + ppm * T) and V = IR
+	double resistance = sensor->readVoltage_mV() / sensor->readCurrent_mA();
+	return (resistance / resistanceAtZero - 1000000) / ppmPerDegree;
+}

--- a/src/sensors/PPG102A6.cpp
+++ b/src/sensors/PPG102A6.cpp
@@ -5,14 +5,16 @@
 PPG102A6::PPG102A6(ADS7828* sensor, int channel, int gpioPin) {
 	resistanceAtZero = 1000;
 	ppmPerDegree = 3850;
-	this->sensor = sensor;
+	topVoltage = 5;
+	
 	// Expected resistance of the RTD at 50 degrees C.
 	// Choosing this value maximizes the minimum value for
 	// d(Voltage)/d(Temperature) on the range -40 to +50
 	// degrees C. If this exact value of resistor cannot be
-	// ordered, the real value should be used.
-	this->dividerResistance = 1192.5;
+	// ordered, the real value should be placed here instead.
+	dividerResistance = 1192.5;
 
+	this->sensor = sensor;
 	this->channel = channel;
 	this->gpioPin = gpioPin;
 
@@ -21,13 +23,17 @@ PPG102A6::PPG102A6(ADS7828* sensor, int channel, int gpioPin) {
 	digitalWrite(gpioPin, LOW);
 }
 
-double PPG102A6::getTemperature(int& err) {
+Status PPG102A6::getTemperature(double& value) {
 	digitalWrite(gpioPin, HIGH);
-	double voltage = sensor->readChannelCommonAnode(channel, err);
+	double voltage = topVoltage / 2;
+	Status s = sensor->readChannelCommonAnode(channel, voltage);
 	digitalWrite(gpioPin, LOW);
-	// using V = IR
+	// using V = IR, assuming low-side reference resistor
 	double current = voltage / dividerResistance;
-	double resistance = voltage / current;
+	double resistance = (topVoltage - voltage) / current;
 	// using R = R0 * (10^6 + ppm * T)
-	return (resistance / resistanceAtZero - 1000000) / ppmPerDegree;
+	if (s == SUCCESS) {
+		value = (resistance / resistanceAtZero - 1000000) / ppmPerDegree;
+	}
+	return s;
 }

--- a/src/sensors/PPG102A6.cpp
+++ b/src/sensors/PPG102A6.cpp
@@ -21,9 +21,9 @@ PPG102A6::PPG102A6(ADS7828* sensor, int channel, int gpioPin) {
 	digitalWrite(gpioPin, LOW);
 }
 
-double PPG102A6::getTemperature() {
+double PPG102A6::getTemperature(int& err) {
 	digitalWrite(gpioPin, HIGH);
-	double voltage = sensor->readChannelCommonAnode(channel);
+	double voltage = sensor->readChannelCommonAnode(channel, err);
 	digitalWrite(gpioPin, LOW);
 	// using V = IR
 	double current = voltage / dividerResistance;

--- a/src/sensors/PPG102A6.h
+++ b/src/sensors/PPG102A6.h
@@ -5,12 +5,15 @@ class ina260;
 
 class PPG102A6 {
     public:
-        PPG102A6(ina260* sensor);
+        PPG102A6(ADS7828* sensor, int channel, int gpioPin);
         double getTemperature();
     private:
         double resistanceAtZero;
         double ppmPerDegree;
-        ina260* sensor;
+        ADS7828* sensor;
+        double dividerResistance;
+        int channel;
+        int gpioPin;
 };
 
 #endif

--- a/src/sensors/PPG102A6.h
+++ b/src/sensors/PPG102A6.h
@@ -1,0 +1,16 @@
+#ifndef PPG102A6
+#define PPG102A6
+
+class ina260;
+
+class PPG102A6 {
+    public:
+        PPG102A6(ina260* sensor);
+        double getTemperature();
+    private:
+        double resistanceAtZero;
+        double ppmPerDegree;
+        ina260* sensor;
+};
+
+#endif

--- a/src/sensors/PPG102A6.h
+++ b/src/sensors/PPG102A6.h
@@ -6,7 +6,9 @@ class ina260;
 class PPG102A6 {
     public:
         PPG102A6(ADS7828* sensor, int channel, int gpioPin);
-        double getTemperature();
+        // note that there are no error codes related to the gpio pin because
+        // gpio failures are silent in the wiringpi library
+        double getTemperature(int& err);
     private:
         double resistanceAtZero;
         double ppmPerDegree;

--- a/src/sensors/PPG102A6.h
+++ b/src/sensors/PPG102A6.h
@@ -8,12 +8,13 @@ class PPG102A6 {
         PPG102A6(ADS7828* sensor, int channel, int gpioPin);
         // note that there are no error codes related to the gpio pin because
         // gpio failures are silent in the wiringpi library
-        double getTemperature(int& err);
+        [[nodiscard]] Status getTemperature(double& value);
     private:
         double resistanceAtZero;
         double ppmPerDegree;
         ADS7828* sensor;
         double dividerResistance;
+        double topVoltage;
         int channel;
         int gpioPin;
 };

--- a/src/sensors/TMP36.cpp
+++ b/src/sensors/TMP36.cpp
@@ -9,7 +9,12 @@ TMP36::TMP36(ADS7828* sensor, int channel) {
 	this->channel = channel;
 }
 
-double TMP36::getTemperature(int& err) {
+Status TMP36::getTemperature(double& value) {
 	// using V = vAtZero + T * vPerDeg
-	return (sensor->readChannelCommonAnode(channel, err)) * 1000 - voltageAtZero) / voltagePerDegree;
+	double voltage;
+	Status s = sensor->readChannelCommonAnode(channel, value));
+	if (s == SUCCESS) {
+		value = (voltage * 1000 - voltageAtZero) / voltagePerDegree;
+	}
+	return s;
 }

--- a/src/sensors/TMP36.cpp
+++ b/src/sensors/TMP36.cpp
@@ -2,9 +2,14 @@
 
 #include "ADS7828.h"
 
-TMP36::TMP36(ADS7828* sensor) : voltageAtZero(0.5), voltagePerDegree(0.01), sensor(sensor) {}
+TMP36::TMP36(ADS7828* sensor, int channel) {
+	voltageAtZero = 0.5;
+	voltagePerDegree = 0.01;
+	this->sensor = sensor;
+	this->channel = channel;
+}
 
-double TMP36::getTemperature() {
+double TMP36::getTemperature(int& err) {
 	// using V = vAtZero + T * vPerDeg
-	return (sensor->readChannelCommonAnode(channel)) * 1000 - voltageAtZero) / voltagePerDegree;
+	return (sensor->readChannelCommonAnode(channel, err)) * 1000 - voltageAtZero) / voltagePerDegree;
 }

--- a/src/sensors/TMP36.cpp
+++ b/src/sensors/TMP36.cpp
@@ -1,0 +1,10 @@
+#include "TMP36.h"
+
+#include "ina260.h"
+
+TMP36::TMP36(ina260* sensor) : voltageAtZero(0.5), voltagePerDegree(0.01), sensor(sensor) {}
+
+double TMP36::getTemperature() {
+	// using V = vAtZero + T * vPerDeg
+	return (sensor->readVoltage_mV() * 1000 - voltageAtZero) / voltagePerDegree;
+}

--- a/src/sensors/TMP36.cpp
+++ b/src/sensors/TMP36.cpp
@@ -1,10 +1,10 @@
 #include "TMP36.h"
 
-#include "ina260.h"
+#include "ADS7828.h"
 
-TMP36::TMP36(ina260* sensor) : voltageAtZero(0.5), voltagePerDegree(0.01), sensor(sensor) {}
+TMP36::TMP36(ADS7828* sensor) : voltageAtZero(0.5), voltagePerDegree(0.01), sensor(sensor) {}
 
 double TMP36::getTemperature() {
 	// using V = vAtZero + T * vPerDeg
-	return (sensor->readVoltage_mV() * 1000 - voltageAtZero) / voltagePerDegree;
+	return (sensor->readChannelCommonAnode(channel)) * 1000 - voltageAtZero) / voltagePerDegree;
 }

--- a/src/sensors/TMP36.h
+++ b/src/sensors/TMP36.h
@@ -1,0 +1,16 @@
+#ifndef TMP36
+#define TMP36
+
+class ina260;
+
+class TMP36 {
+public:
+    TMP36(ina260* sensor);
+    double getTemperature();
+private:
+    double voltageAtZero;
+    double voltagePerDegree;
+    ina260* sensor;
+};
+
+#endif

--- a/src/sensors/TMP36.h
+++ b/src/sensors/TMP36.h
@@ -6,7 +6,7 @@ class ADS7828;
 class TMP36 {
 public:
     TMP36(ADS7828* sensor, int channel);
-    double getTemperature(int& err);
+    [[nodiscard]] Status getTemperature(double& value);
 private:
     double voltageAtZero;
     double voltagePerDegree;

--- a/src/sensors/TMP36.h
+++ b/src/sensors/TMP36.h
@@ -1,16 +1,17 @@
 #ifndef TMP36
 #define TMP36
 
-class ina260;
+class ADS7828;
 
 class TMP36 {
 public:
-    TMP36(ina260* sensor);
+    TMP36(ADS7828* sensor, int channel);
     double getTemperature();
 private:
     double voltageAtZero;
     double voltagePerDegree;
-    ina260* sensor;
+    ADS7828* sensor;
+    int channel;
 };
 
 #endif

--- a/src/sensors/TMP36.h
+++ b/src/sensors/TMP36.h
@@ -6,7 +6,7 @@ class ADS7828;
 class TMP36 {
 public:
     TMP36(ADS7828* sensor, int channel);
-    double getTemperature();
+    double getTemperature(int& err);
 private:
     double voltageAtZero;
     double voltagePerDegree;


### PR DESCRIPTION
Added gitignore for Visual Studio files
Added support class for platinum RTD temperature sensor model PPG102A6
Added support class for analog IC temperature sensor model TMP36

Note that, due to the digital nature of the rPi and the analog nature of the sensors, each instance of either support class is associated with an instance of the INA260 voltage/current sensor class.